### PR TITLE
Whole line highlighting

### DIFF
--- a/ScintillaDiff/HighLight.cs
+++ b/ScintillaDiff/HighLight.cs
@@ -34,18 +34,18 @@ namespace ScintillaDiff
     /// </summary>
     public class Highlight
     {
-        /// <summary>
-        /// Highlights a given range with a given color and given alpha values of the <see cref="Scintilla"/> control.
-        /// </summary>
-        /// <param name="scintilla">The scintilla of which words to highlight.</param>
-        /// <param name="num">The indicator number for the <paramref name="scintilla"/>.Indicators 0-7 could be in use by a lexer so use a higher value.</param>
-        /// <param name="start">The starting position of the highlight area.</param>
-        /// <param name="length">The length of the highlight area.</param>
-        /// <param name="color">The color to use for the highlight.</param>
-        /// <param name="alpha">The transparency value of the indicator.</param>
-        /// <param name="outlineAlpha">The transparency value of the indicator outline.</param>
-        /// <note>(C): https://github.com/jacobslusser/ScintillaNET/wiki/Find-and-Highlight-Words</note>
-        public static void HighlightRange(Scintilla scintilla, int num, int start, int length, Color color, byte alpha = 255, byte outlineAlpha = 255)
+		/// <summary>
+		/// Highlights a given range with a given color and given alpha values of the <see cref="Scintilla"/> control.
+		/// </summary>
+		/// <param name="scintilla">The scintilla of which words to highlight.</param>
+		/// <param name="num">The indicator number for the <paramref name="scintilla"/>.Indicators 0-7 could be in use by a lexer so use a higher value.</param>
+		/// <param name="start">The starting position of the highlight area.</param>
+		/// <param name="length">The length of the highlight area.</param>
+		/// <param name="color">The color to use for the highlight.</param>
+		/// <param name="alpha">The transparency value of the indicator.</param>
+		/// <param name="outlineAlpha">The transparency value of the indicator outline.</param>
+		/// <note>(C): https://github.com/jacobslusser/ScintillaNET/wiki/Find-and-Highlight-Words</note>
+		public static void HighlightRange(Scintilla scintilla, int num, int start, int length, Color color, byte alpha = 255, byte outlineAlpha = 255)
         {
             // Remove all uses of our indicator
             scintilla.IndicatorCurrent = num;
@@ -60,6 +60,21 @@ namespace ScintillaDiff
             // Mark the search position with the current indicator..
             scintilla.IndicatorFillRange(start, length);
         }
+
+		/// <summary>
+		/// Highlights an entire line
+		/// </summary>
+		/// <param name="scintilla">The scintilla of which contains the line to highlight.</param>
+		/// <param name="lineIndex">The index of the line to be highlighted within the scintilla.</param>
+		/// <param name="changeType">The type of change has been made, indicating which colour to highlight the line with.</param>
+		public static void HighlightLine(Scintilla scintilla, int lineIndex, int changeType)
+		{
+			int start = scintilla.Lines[lineIndex].Position;
+			int length = scintilla.Lines[lineIndex].Length;
+
+			scintilla.StartStyling(start);
+			scintilla.SetStyling(length, changeType);
+		}
 
         /// <summary>
         /// Clears the given style form a <see cref="Scintilla"/>.

--- a/ScintillaDiff/ScintillaDiffControl.cs
+++ b/ScintillaDiff/ScintillaDiffControl.cs
@@ -570,6 +570,7 @@ namespace ScintillaDiff
         private void RecalculateSize()
         {
             int size = scMain.ClientSize.Width - scMain.SplitterWidth;
+			if (size >= 0)
             scMain.SplitterDistance = size / 2;
         }
 


### PR DESCRIPTION
**What?**

- Added IsEntireLineHighlighted attribute, which when set to true, will set the entire background of a line to a given colour corresponding to the change type for that line.
- Prevented a crash when minimising the TestApp (or any form that contains this control), which I found was caused by attempting to resize the splitter distance to a negative size. Added a quick check for this before setting the splitter distance.

**Why?**

I was hoping to use this control with styling similar to diff viewing tools such as Smartbear's Collaborator code reviewing tool (https://smartbear.com/product/collaborator/features/track-manage-defects/). 

 